### PR TITLE
Refactor highlighter to use AVAILABLE_LANGUAGES constant

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -67,7 +67,10 @@ export default function Home() {
   }, [simpleSteps, selectedLang, simpleShowLineNumbers, simpleStartLine]);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const [stepLayouts, setStepLayouts] = useState<StepLayout[] | null>(null);
-  const [canvasDimensions, setCanvasDimensions] = useState<CanvasDimensions>({ width: 1920, height: 1080 });
+  const [canvasDimensions, setCanvasDimensions] = useState<CanvasDimensions>({
+    width: 1920,
+    height: 1080,
+  });
   const [layoutError, setLayoutError] = useState<string | null>(null);
 
   // Store tokenized data for reuse in export
@@ -143,11 +146,13 @@ export default function Home() {
       if (cancelled) return;
 
       // Calculate max gutter width across all steps for consistent token positioning
-      const maxDigits = Math.max(...stepData.map((data) => {
-        const lineCount = data.lines.length;
-        const lastLineNumber = data.startLine + Math.max(0, lineCount - 1);
-        return String(lastLineNumber).length;
-      }));
+      const maxDigits = Math.max(
+        ...stepData.map((data) => {
+          const lineCount = data.lines.length;
+          const lastLineNumber = data.startLine + Math.max(0, lineCount - 1);
+          return String(lastLineNumber).length;
+        }),
+      );
       const maxGutterWidth = simpleShowLineNumbers
         ? Math.ceil(maxDigits * charWidth + GUTTER_PADDING * 2)
         : 0;
@@ -158,15 +163,15 @@ export default function Home() {
           tokenLines: data.lines,
           charWidth,
           paddingX: previewCfg.paddingX,
-          gutterWidth: maxGutterWidth,  // Use max gutter width for consistent positioning
-          minWidth: 0,  // No minimum for preview - shrink to fit
+          gutterWidth: maxGutterWidth, // Use max gutter width for consistent positioning
+          minWidth: 0, // No minimum for preview - shrink to fit
         });
 
         const requiredHeight = calculateCanvasHeight({
           lineCount: data.lines.length,
           lineHeight: previewCfg.lineHeight,
           paddingY: previewCfg.paddingY,
-          minHeight: 0,  // No minimum for preview - shrink to fit
+          minHeight: 0, // No minimum for preview - shrink to fit
         });
 
         return { width: requiredWidth, height: requiredHeight };
@@ -394,14 +399,10 @@ export default function Home() {
     const isAddingAtEnd = insertAt === simpleSteps.length;
 
     const newStep = { id: nanoid(), code: "// New step" };
-    setSimpleSteps([
-      ...simpleSteps.slice(0, insertAt),
-      newStep,
-      ...simpleSteps.slice(insertAt)
-    ]);
+    setSimpleSteps([...simpleSteps.slice(0, insertAt), newStep, ...simpleSteps.slice(insertAt)]);
 
     if (isAddingAtEnd) {
-      setScrollToEndTrigger(prev => prev + 1);
+      setScrollToEndTrigger((prev) => prev + 1);
     }
   };
 
@@ -436,11 +437,13 @@ export default function Home() {
     const charWidth = ctx.measureText("M").width;
 
     // Calculate max gutter width across all steps for consistent token positioning
-    const maxDigits = Math.max(...stepTokenDataRef.current.map((data) => {
-      const lineCount = data.lines.length;
-      const lastLineNumber = data.startLine + Math.max(0, lineCount - 1);
-      return String(lastLineNumber).length;
-    }));
+    const maxDigits = Math.max(
+      ...stepTokenDataRef.current.map((data) => {
+        const lineCount = data.lines.length;
+        const lastLineNumber = data.startLine + Math.max(0, lineCount - 1);
+        return String(lastLineNumber).length;
+      }),
+    );
     const maxGutterWidth = simpleShowLineNumbers
       ? Math.ceil(maxDigits * charWidth + GUTTER_PADDING * 2)
       : 0;
@@ -451,7 +454,7 @@ export default function Home() {
         tokenLines: data.lines,
         charWidth,
         paddingX: exportCfg.paddingX,
-        gutterWidth: maxGutterWidth,  // Use max gutter width for consistent positioning
+        gutterWidth: maxGutterWidth, // Use max gutter width for consistent positioning
         minWidth: 0,
       });
 

--- a/app/lib/magicMove/shikiHighlighter.ts
+++ b/app/lib/magicMove/shikiHighlighter.ts
@@ -93,51 +93,7 @@ async function getHighlighterOnce() {
           "vitesse-light",
           "vesper",
         ],
-        langs: [
-          // Web fundamentals
-          "javascript",
-          "typescript",
-          "tsx",
-          "jsx",
-          "html",
-          "css",
-          "json",
-          "markdown",
-          // Shell
-          "bash",
-          "shell",
-          // Systems
-          "c",
-          "cpp",
-          "rust",
-          "go",
-          // JVM / .NET
-          "java",
-          "kotlin",
-          "scala",
-          "csharp",
-          // Scripting
-          "python",
-          "ruby",
-          "php",
-          "lua",
-          // Mobile
-          "swift",
-          "dart",
-          // Functional
-          "elixir",
-          // Frontend frameworks
-          "svelte",
-          "vue",
-          // Data / Config
-          "sql",
-          "yaml",
-          "toml",
-          "graphql",
-          // DevOps
-          "dockerfile",
-          "terraform",
-        ],
+        langs: [...AVAILABLE_LANGUAGES],
       });
     })();
   }


### PR DESCRIPTION
## Summary
- Remove duplicated language list in `getHighlighterOnce()` and reference the existing `AVAILABLE_LANGUAGES` constant instead
- Apply consistent code formatting

## Test plan
- [ ] Verify syntax highlighting works for all supported languages
- [ ] Confirm no visual regressions in the editor preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)