### PR TITLE
Reduce default transition duration from 1.2s to 0.7s

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -49,7 +49,7 @@ export default function Home() {
 
   const [theme, setTheme] = useState<ShikiThemeChoice>("vitesse-dark");
   const [fps, setFps] = useState<number>(60);
-  const [transitionMs, setTransitionMs] = useState<number>(1200);
+  const [transitionMs, setTransitionMs] = useState<number>(700);
   const [startHoldMs, setStartHoldMs] = useState<number>(500);
   const [betweenHoldMs, setBetweenHoldMs] = useState<number>(200);
   const [endHoldMs, setEndHoldMs] = useState<number>(500);


### PR DESCRIPTION
## Summary
- Changed the default transition duration from 1200ms (1.2s) to 700ms (0.7s) for snappier animations

## Test plan
- [ ] Open the editor and verify the default transition slider shows 0.7s
- [ ] Play a transition and confirm it feels faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)