### PR TITLE
Add ray.so-style editor design with macOS title bar dots

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -171,6 +171,7 @@ export default function Home() {
           lineCount: data.lines.length,
           lineHeight: previewCfg.lineHeight,
           paddingY: previewCfg.paddingY,
+          titleBarHeight: previewCfg.titleBarHeight,
           minHeight: 0, // No minimum for preview - shrink to fit
         });
 
@@ -462,6 +463,7 @@ export default function Home() {
         lineCount: data.lines.length,
         lineHeight: exportCfg.lineHeight,
         paddingY: exportCfg.paddingY,
+        titleBarHeight: exportCfg.titleBarHeight,
         minHeight: 0,
       });
 

--- a/app/lib/magicMove/canvasRenderer.ts
+++ b/app/lib/magicMove/canvasRenderer.ts
@@ -1,5 +1,38 @@
 import type { CanvasLayoutConfig, LayoutResult, RenderTheme } from "./codeLayout";
 
+function drawTitleBar(opts: {
+  ctx: CanvasRenderingContext2D;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  theme: RenderTheme;
+}) {
+  const { ctx, x, y, w, h, theme } = opts;
+  const dotColor = theme === "dark" ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.13)";
+  const dotRadius = Math.round(h * 0.14);
+  const dotGap = Math.round(dotRadius * 2.5);
+  const dotsY = y + h / 2;
+  const dotsX0 = x + Math.round(h * 0.55);
+
+  // Subtle separator line at the bottom of the title bar
+  const sepColor = theme === "dark" ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)";
+  ctx.strokeStyle = sepColor;
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(x, y + h);
+  ctx.lineTo(x + w, y + h);
+  ctx.stroke();
+
+  // Draw three muted dots
+  for (let i = 0; i < 3; i++) {
+    ctx.beginPath();
+    ctx.arc(dotsX0 + i * dotGap, dotsY, dotRadius, 0, Math.PI * 2);
+    ctx.fillStyle = dotColor;
+    ctx.fill();
+  }
+}
+
 function roundedRectPath(
   ctx: CanvasRenderingContext2D,
   x: number,
@@ -60,19 +93,43 @@ export function drawCodeFrame(opts: {
   const cardW = config.canvasWidth - 64;
   const cardH = config.canvasHeight - 64;
   const cardBg = opts.theme === "dark" ? "rgba(255,255,255,0.04)" : "rgba(17,24,39,0.03)";
-  const cardBorder = opts.theme === "dark" ? "rgba(255,255,255,0.08)" : "rgba(17,24,39,0.10)";
+  const cardBorder = opts.theme === "dark" ? "rgba(255,255,255,0.06)" : "rgba(17,24,39,0.08)";
 
-  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 18);
+  // Card shadow
+  ctx.save();
+  ctx.shadowColor = "rgba(0,0,0,0.25)";
+  ctx.shadowBlur = 32;
+  ctx.shadowOffsetX = 0;
+  ctx.shadowOffsetY = 8;
+  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 20);
   ctx.fillStyle = cardBg;
   ctx.fill();
+  ctx.restore();
+
+  // Card border
+  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 20);
   ctx.strokeStyle = cardBorder;
   ctx.lineWidth = 1;
   ctx.stroke();
 
   ctx.save();
   ctx.beginPath();
-  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 18);
+  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 20);
   ctx.clip();
+
+  // Title bar with macOS dots
+  const titleBarH = config.titleBarHeight;
+  if (titleBarH > 0) {
+    drawTitleBar({
+      ctx,
+      x: cardX,
+      y: cardY,
+      w: cardW,
+      h: titleBarH,
+      theme: opts.theme,
+    });
+    ctx.translate(0, titleBarH);
+  }
 
   // Gutter (line numbers)
   const gutterEnabled = opts.showLineNumbers ?? layout.gutter.enabled;

--- a/app/lib/magicMove/codeLayout.ts
+++ b/app/lib/magicMove/codeLayout.ts
@@ -12,6 +12,7 @@ export type CanvasLayoutConfig = {
   fontFamily: string;
   showLineNumbers: boolean;
   startLine: number;
+  titleBarHeight: number;
 };
 
 /** Padding on each side of the gutter (left and right of line numbers) */
@@ -53,6 +54,7 @@ export function makeDefaultLayoutConfig(): CanvasLayoutConfig {
       'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
     showLineNumbers: false,
     startLine: 1,
+    titleBarHeight: 48,
   };
 }
 
@@ -68,6 +70,7 @@ export function makePreviewLayoutConfig(): CanvasLayoutConfig {
       'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
     showLineNumbers: false,
     startLine: 1,
+    titleBarHeight: 32,
   };
 }
 
@@ -79,13 +82,14 @@ export function calculateCanvasHeight(opts: {
   lineCount: number;
   lineHeight: number;
   paddingY: number;
+  titleBarHeight?: number;
   minHeight?: number;
 }): number {
-  const { lineCount, lineHeight, paddingY, minHeight = 0 } = opts;
+  const { lineCount, lineHeight, paddingY, titleBarHeight = 0, minHeight = 0 } = opts;
   const contentHeight = lineCount * lineHeight;
   // Add extra padding at bottom for visual balance
   const bottomBuffer = Math.ceil(lineHeight / 2);
-  const totalHeight = contentHeight + paddingY * 2 + bottomBuffer;
+  const totalHeight = contentHeight + paddingY * 2 + titleBarHeight + bottomBuffer;
   return Math.ceil(Math.max(minHeight, totalHeight));
 }
 

--- a/app/lib/magicMove/shikiHighlighter.ts
+++ b/app/lib/magicMove/shikiHighlighter.ts
@@ -82,6 +82,26 @@ export function getThemeVariant(theme: ShikiThemeChoice): "light" | "dark" {
   return lightThemes.includes(theme) ? "light" : "dark";
 }
 
+const THEME_BG_COLORS: Record<ShikiThemeChoice, string> = {
+  "github-light": "#ffffff",
+  "github-dark": "#24292e",
+  "nord": "#2e3440",
+  "one-dark-pro": "#282c34",
+  "vitesse-dark": "#121212",
+  "vitesse-light": "#ffffff",
+  "vesper": "#101010",
+  "kanagawa-dragon": "#181616",
+  "kanagawa-lotus": "#f2ecbc",
+};
+
+/**
+ * Synchronous lookup for a theme's background color.
+ * Avoids async tokenization when only the bg color is needed (e.g. for editor styling).
+ */
+export function getThemeBgColor(theme: ShikiThemeChoice): string {
+  return THEME_BG_COLORS[theme];
+}
+
 export type TokenLine = {
   tokens: { content: string; color: string }[];
 };

--- a/components/code-editor.tsx
+++ b/components/code-editor.tsx
@@ -80,8 +80,8 @@ export function CodeEditor({
     <div className="flex flex-col gap-1.5 w-full">
       <div
         className={cn(
-          "relative font-mono text-sm leading-relaxed rounded-md overflow-hidden border transition-colors focus-within:ring-2 focus-within:ring-primary/20",
-          isOverLimit ? "border-warning/50" : "",
+          "relative font-mono text-sm leading-relaxed rounded-b-xl overflow-hidden transition-colors focus-within:ring-1 focus-within:ring-white/10",
+          isOverLimit ? "ring-1 ring-warning/50" : "",
           className,
         )}
         style={{ maxHeight }}

--- a/components/step-editor-item.tsx
+++ b/components/step-editor-item.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Trash2 } from "lucide-react";
 import { CodeEditor } from "./code-editor";
 import type { ShikiThemeChoice } from "@/app/lib/magicMove/shikiHighlighter";
+import { getThemeBgColor, getThemeVariant } from "@/app/lib/magicMove/shikiHighlighter";
 
 interface StepEditorItemProps {
   index: number;
@@ -25,35 +25,65 @@ export function StepEditorItem({
   language,
   theme,
 }: StepEditorItemProps) {
+  const bgColor = getThemeBgColor(theme);
+  const variant = getThemeVariant(theme);
+  const dotColor = variant === "dark" ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.15)";
+
   return (
-    <div className="group relative">
-      {/* Step Header */}
-      <div className="flex items-center justify-between mb-2">
-        <Label className="text-xs font-mono text-muted-foreground">Step {index + 1}</Label>
-        {canRemove && (
+    <div className="group relative shadow-lg shadow-black/10 rounded-xl overflow-hidden ring-1 ring-white/[0.06]">
+      {/* Title bar */}
+      <div
+        className="flex items-center h-9 px-3.5 rounded-t-xl"
+        style={{ backgroundColor: bgColor }}
+      >
+        {/* macOS dots */}
+        <div className="flex items-center gap-[7px]">
+          <span
+            className="block w-[11px] h-[11px] rounded-full"
+            style={{ backgroundColor: dotColor }}
+          />
+          <span
+            className="block w-[11px] h-[11px] rounded-full"
+            style={{ backgroundColor: dotColor }}
+          />
+          <span
+            className="block w-[11px] h-[11px] rounded-full"
+            style={{ backgroundColor: dotColor }}
+          />
+        </div>
+
+        {/* Step label */}
+        <span
+          className="flex-1 text-center text-[11px] font-mono select-none"
+          style={{ color: variant === "dark" ? "rgba(255,255,255,0.35)" : "rgba(0,0,0,0.3)" }}
+        >
+          Step {index + 1}
+        </span>
+
+        {/* Delete button */}
+        {canRemove ? (
           <Button
             variant="ghost"
             size="icon"
-            className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
+            className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive"
             onClick={onRemove}
           >
-            <Trash2 className="w-3.5 h-3.5" />
+            <Trash2 className="w-3 h-3" />
           </Button>
+        ) : (
+          <div className="w-5" />
         )}
       </div>
 
       {/* Code Editor */}
-      <div className="relative">
-        <CodeEditor
-          language={language}
-          theme={theme}
-          value={code}
-          onChange={onCodeChange}
-          placeholder={`// Enter code for step ${index + 1}...`}
-          className="bg-background"
-          maxLines={30}
-        />
-      </div>
+      <CodeEditor
+        language={language}
+        theme={theme}
+        value={code}
+        onChange={onCodeChange}
+        placeholder={`// Enter code for step ${index + 1}...`}
+        maxLines={30}
+      />
     </div>
   );
 }

--- a/components/steps-editor.tsx
+++ b/components/steps-editor.tsx
@@ -103,7 +103,7 @@ export function StepsEditor({
       />
 
       <ScrollArea ref={scrollRef} className="flex-1 w-full min-h-0">
-        <div className="py-2 px-4 space-y-2 max-w-4xl mx-auto w-full pb-4">
+        <div className="py-2 px-4 space-y-4 max-w-4xl mx-auto w-full pb-4">
           {steps.map((step, index) => (
             <Fragment key={step.id}>
               <StepInsertDivider onInsert={() => onInsertStep(index)} />


### PR DESCRIPTION
## Summary
- Adds macOS-style title bar with muted gray dots to both canvas renderer (preview/export) and editor UI cards
- Softens card styling: 20px corner radius, subtle ring borders, drop shadows
- Adds `getThemeBgColor()` utility for synchronous theme background color lookup
- Title bar offset in canvas via `ctx.translate()` — zero impact on animation logic

## Test plan
- [ ] Open editor page — verify each step card shows title bar with 3 muted dots and "Step N" label
- [ ] Verify canvas preview renders dots in the title bar area
- [ ] Switch between light and dark Shiki themes — dots and title bar should adapt
- [ ] Export video and verify title bar/dots appear in output
- [ ] Add/remove steps — layout should remain correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)