### PR TITLE
Fix canvas preview: larger dots, no outer card, transparent gutter

### DIFF
--- a/app/lib/magicMove/canvasRenderer.ts
+++ b/app/lib/magicMove/canvasRenderer.ts
@@ -10,10 +10,10 @@ function drawTitleBar(opts: {
 }) {
   const { ctx, x, y, w, h, theme } = opts;
   const dotColor = theme === "dark" ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.13)";
-  const dotRadius = Math.round(h * 0.14);
-  const dotGap = Math.round(dotRadius * 2.5);
+  const dotRadius = Math.round(h * 0.18);
+  const dotGap = Math.round(dotRadius * 2.6);
   const dotsY = y + h / 2;
-  const dotsX0 = x + Math.round(h * 0.55);
+  const dotsX0 = x + Math.round(h * 0.6);
 
   // Subtle separator line at the bottom of the title bar
   const sepColor = theme === "dark" ? "rgba(255,255,255,0.06)" : "rgba(0,0,0,0.06)";
@@ -87,34 +87,9 @@ export function drawCodeFrame(opts: {
 
   clearAndPaintBackground({ ctx, config, bg: layout.bg });
 
-  // Card background - use config dimensions (logical size), not canvas dimensions (may be 2x for retina)
-  const cardX = 32;
-  const cardY = 32;
-  const cardW = config.canvasWidth - 64;
-  const cardH = config.canvasHeight - 64;
-  const cardBg = opts.theme === "dark" ? "rgba(255,255,255,0.04)" : "rgba(17,24,39,0.03)";
-  const cardBorder = opts.theme === "dark" ? "rgba(255,255,255,0.06)" : "rgba(17,24,39,0.08)";
-
-  // Card shadow
+  // Clip to rounded canvas bounds (no inner card)
   ctx.save();
-  ctx.shadowColor = "rgba(0,0,0,0.25)";
-  ctx.shadowBlur = 32;
-  ctx.shadowOffsetX = 0;
-  ctx.shadowOffsetY = 8;
-  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 20);
-  ctx.fillStyle = cardBg;
-  ctx.fill();
-  ctx.restore();
-
-  // Card border
-  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 20);
-  ctx.strokeStyle = cardBorder;
-  ctx.lineWidth = 1;
-  ctx.stroke();
-
-  ctx.save();
-  ctx.beginPath();
-  roundedRectPath(ctx, cardX, cardY, cardW, cardH, 20);
+  roundedRectPath(ctx, 0, 0, config.canvasWidth, config.canvasHeight, 16);
   ctx.clip();
 
   // Title bar with macOS dots
@@ -122,9 +97,9 @@ export function drawCodeFrame(opts: {
   if (titleBarH > 0) {
     drawTitleBar({
       ctx,
-      x: cardX,
-      y: cardY,
-      w: cardW,
+      x: 0,
+      y: 0,
+      w: config.canvasWidth,
       h: titleBarH,
       theme: opts.theme,
     });
@@ -138,11 +113,9 @@ export function drawCodeFrame(opts: {
   if (gutterEnabled && gutterWidth > 0) {
     const x0 = config.paddingX;
     const y0 = config.paddingY;
-    const h = cardH - (config.paddingY - (cardY + 0));
+    const h = config.canvasHeight;
 
-    ctx.fillStyle = opts.theme === "dark" ? "rgba(0,0,0,0.16)" : "rgba(255,255,255,0.40)";
-    ctx.fillRect(x0, y0 - 8, gutterWidth + 12, h);
-
+    // Divider line only — no background fill (transparent gutter like ray.so)
     ctx.strokeStyle = layout.gutter.dividerColor;
     ctx.beginPath();
     ctx.moveTo(x0 + gutterWidth + 8, y0 - 8);
@@ -151,7 +124,7 @@ export function drawCodeFrame(opts: {
 
     const startLine = opts.startLine ?? config.startLine;
     const lineCount =
-      opts.lineCount ?? Math.round((cardH - config.paddingY * 2) / config.lineHeight);
+      opts.lineCount ?? Math.round((config.canvasHeight - config.paddingY * 2) / config.lineHeight);
     ctx.font = `${config.fontSize}px ${config.fontFamily}`;
     ctx.textBaseline = "top";
     ctx.fillStyle = layout.gutter.textColor;


### PR DESCRIPTION
## Summary
- Larger title bar dots (radius 0.14→0.18) for better proportions
- Removed inner card background, border, and shadow — theme bg fills edge-to-edge
- Removed gutter background fill — line numbers on same bg as code, only a subtle divider
- Clip path moved to full canvas bounds (0,0) with 16px radius, fixing gutter corner clipping

## Test plan
- [ ] Dots visibly larger and well-proportioned in title bar
- [ ] No outer card border/shadow — code fills canvas edge-to-edge on theme bg
- [ ] Line numbers: no separate background, just a subtle vertical divider
- [ ] Rounded corners at canvas edges, not clipping into content
- [ ] Export video shows same improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)