### PR TITLE
Reduce gutter padding for tighter line numbers

### DIFF
--- a/app/lib/magicMove/codeLayout.ts
+++ b/app/lib/magicMove/codeLayout.ts
@@ -16,7 +16,7 @@ export type CanvasLayoutConfig = {
 };
 
 /** Padding on each side of the gutter (left and right of line numbers) */
-export const GUTTER_PADDING = 16;
+export const GUTTER_PADDING = 8;
 
 export type LaidToken = {
   key: string;


### PR DESCRIPTION
## Summary
- Reduced `GUTTER_PADDING` from 16px to 8px per side (32px→16px total)
- Max line count is 2 digits so the extra space was unnecessary

## Test plan
- [ ] Line numbers sit closer to the left edge and divider
- [ ] No clipping or overlap with code content

🤖 Generated with [Claude Code](https://claude.com/claude-code)