### PR TITLE
Polish canvas: remove separator, tighten gutter, match editor dots

### DIFF
--- a/app/lib/magicMove/canvasRenderer.ts
+++ b/app/lib/magicMove/canvasRenderer.ts
@@ -113,18 +113,10 @@ export function drawCodeFrame(opts: {
   if (gutterEnabled && gutterWidth > 0) {
     const x0 = config.paddingX;
     const y0 = config.paddingY;
-    const h = config.canvasHeight;
-
-    // Divider line only — no background fill (transparent gutter like ray.so)
-    ctx.strokeStyle = layout.gutter.dividerColor;
-    ctx.beginPath();
-    ctx.moveTo(x0 + gutterWidth + 8, y0 - 8);
-    ctx.lineTo(x0 + gutterWidth + 8, y0 - 8 + h);
-    ctx.stroke();
-
     const startLine = opts.startLine ?? config.startLine;
     const lineCount =
       opts.lineCount ?? Math.round((config.canvasHeight - config.paddingY * 2) / config.lineHeight);
+
     ctx.font = `${config.fontSize}px ${config.fontFamily}`;
     ctx.textBaseline = "top";
     ctx.fillStyle = layout.gutter.textColor;

--- a/app/lib/magicMove/codeLayout.ts
+++ b/app/lib/magicMove/codeLayout.ts
@@ -16,7 +16,7 @@ export type CanvasLayoutConfig = {
 };
 
 /** Padding on each side of the gutter (left and right of line numbers) */
-export const GUTTER_PADDING = 8;
+export const GUTTER_PADDING = 4;
 
 export type LaidToken = {
   key: string;

--- a/components/step-editor-item.tsx
+++ b/components/step-editor-item.tsx
@@ -37,17 +37,17 @@ export function StepEditorItem({
         style={{ backgroundColor: bgColor }}
       >
         {/* macOS dots */}
-        <div className="flex items-center gap-[7px]">
+        <div className="flex items-center gap-1">
           <span
-            className="block w-[11px] h-[11px] rounded-full"
+            className="block w-3 h-3 rounded-full"
             style={{ backgroundColor: dotColor }}
           />
           <span
-            className="block w-[11px] h-[11px] rounded-full"
+            className="block w-3 h-3 rounded-full"
             style={{ backgroundColor: dotColor }}
           />
           <span
-            className="block w-[11px] h-[11px] rounded-full"
+            className="block w-3 h-3 rounded-full"
             style={{ backgroundColor: dotColor }}
           />
         </div>


### PR DESCRIPTION
## Summary
- Removed gutter divider line entirely for cleaner look
- Reduced `GUTTER_PADDING` from 8px to 4px per side
- Matched editor dots to canvas: 12px diameter (`w-3 h-3`), 4px gap (`gap-1`)

## Test plan
- [ ] No vertical separator line between line numbers and code
- [ ] Line numbers sit closer to code with less wasted space
- [ ] Editor card dots match canvas preview dots in size and spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)