### PR TITLE
Add editable filename input in preview title bar

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -53,6 +53,7 @@ export default function Home() {
   const [startHoldMs, setStartHoldMs] = useState<number>(500);
   const [betweenHoldMs, setBetweenHoldMs] = useState<number>(200);
   const [endHoldMs, setEndHoldMs] = useState<number>(500);
+  const [filename, setFilename] = useState<string>("Untitled-1");
 
   // Compute steps from simple mode
   const steps = useMemo<MagicMoveStep[]>(() => {
@@ -276,6 +277,7 @@ export default function Home() {
           showLineNumbers: only.showLineNumbers,
           startLine: only.startLine,
           lineCount: only.tokenLineCount,
+          // Title is shown via HTML input overlay in preview
         });
         return;
       }
@@ -291,6 +293,7 @@ export default function Home() {
           showLineNumbers: first.showLineNumbers,
           startLine: first.startLine,
           lineCount: first.tokenLineCount,
+          // Title is shown via HTML input overlay in preview
         });
         return;
       }
@@ -315,6 +318,7 @@ export default function Home() {
             prevLineCount: a.tokenLineCount,
             targetLineCount: b.tokenLineCount,
             transitionProgress: progress,
+            // Title is shown via HTML input overlay in preview
           });
           return;
         }
@@ -329,6 +333,7 @@ export default function Home() {
             showLineNumbers: b.showLineNumbers,
             startLine: b.startLine,
             lineCount: b.tokenLineCount,
+            // Title is shown via HTML input overlay in preview
           });
           return;
         }
@@ -344,6 +349,7 @@ export default function Home() {
         showLineNumbers: last.showLineNumbers,
         startLine: last.startLine,
         lineCount: last.tokenLineCount,
+        // Title is shown via HTML input overlay in preview
       });
     },
     [stepLayouts, theme, timeline, transitionMs, canvasDimensions],
@@ -532,6 +538,7 @@ export default function Home() {
           showLineNumbers: only.showLineNumbers,
           startLine: only.startLine,
           lineCount: only.tokenLineCount,
+          title: filename,
         });
         return;
       }
@@ -547,6 +554,7 @@ export default function Home() {
           showLineNumbers: first.showLineNumbers,
           startLine: first.startLine,
           lineCount: first.tokenLineCount,
+          title: filename,
         });
         return;
       }
@@ -571,6 +579,7 @@ export default function Home() {
             prevLineCount: a.tokenLineCount,
             targetLineCount: b.tokenLineCount,
             transitionProgress: progress,
+            title: filename,
           });
           return;
         }
@@ -585,6 +594,7 @@ export default function Home() {
             showLineNumbers: b.showLineNumbers,
             startLine: b.startLine,
             lineCount: b.tokenLineCount,
+            title: filename,
           });
           return;
         }
@@ -600,6 +610,7 @@ export default function Home() {
         showLineNumbers: last.showLineNumbers,
         startLine: last.startLine,
         lineCount: last.tokenLineCount,
+        title: filename,
       });
     };
 
@@ -710,6 +721,8 @@ export default function Home() {
           exportProgress={exportProgress}
           onExport={onExport}
           canExport={canExport}
+          filename={filename}
+          onFilenameChange={setFilename}
         />
       </ResizablePanelGroup>
     </div>

--- a/app/lib/magicMove/canvasRenderer.ts
+++ b/app/lib/magicMove/canvasRenderer.ts
@@ -7,8 +7,9 @@ function drawTitleBar(opts: {
   w: number;
   h: number;
   theme: RenderTheme;
+  title?: string;
 }) {
-  const { ctx, x, y, w, h, theme } = opts;
+  const { ctx, x, y, w, h, theme, title } = opts;
   const dotColor = theme === "dark" ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.13)";
   const dotRadius = Math.round(h * 0.18);
   const dotGap = Math.round(dotRadius * 2.6);
@@ -30,6 +31,17 @@ function drawTitleBar(opts: {
     ctx.arc(dotsX0 + i * dotGap, dotsY, dotRadius, 0, Math.PI * 2);
     ctx.fillStyle = dotColor;
     ctx.fill();
+  }
+
+  // Draw title centered in title bar
+  if (title) {
+    const titleColor = theme === "dark" ? "rgba(255,255,255,0.4)" : "rgba(0,0,0,0.4)";
+    ctx.fillStyle = titleColor;
+    ctx.font = `${Math.round(h * 0.35)}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif`;
+    ctx.textBaseline = "middle";
+    ctx.textAlign = "center";
+    ctx.fillText(title, x + w / 2, y + h / 2);
+    ctx.textAlign = "left"; // Reset to default
   }
 }
 
@@ -82,6 +94,8 @@ export function drawCodeFrame(opts: {
   prevLineCount?: number;
   targetLineCount?: number;
   transitionProgress?: number;
+  // Optional title for the title bar
+  title?: string;
 }) {
   const { ctx, config, layout } = opts;
 
@@ -102,6 +116,7 @@ export function drawCodeFrame(opts: {
       w: config.canvasWidth,
       h: titleBarH,
       theme: opts.theme,
+      title: opts.title,
     });
     ctx.translate(0, titleBarH);
   }

--- a/components/canvas-preview.tsx
+++ b/components/canvas-preview.tsx
@@ -9,6 +9,8 @@ interface CanvasPreviewProps {
   layoutError: string | null;
   onDismissError: () => void;
   isLoading?: boolean;
+  filename: string;
+  onFilenameChange: (value: string) => void;
 }
 
 export function CanvasPreview({
@@ -16,6 +18,8 @@ export function CanvasPreview({
   layoutError,
   onDismissError,
   isLoading,
+  filename,
+  onFilenameChange,
 }: CanvasPreviewProps) {
   const hasShownRef = useRef(false);
   const shouldAnimate = !isLoading && !hasShownRef.current;
@@ -46,6 +50,16 @@ export function CanvasPreview({
             className={`relative shadow-2xl rounded-lg overflow-hidden ring-1 ring-black/5 dark:ring-white/10 bg-zinc-950 ${shouldAnimate ? "opacity-0 animate-[fadeIn_0.3s_ease-in-out_forwards]" : "opacity-100"}`}
           >
             <canvas ref={canvasRef} className="block" />
+            {/* Filename input overlay - displays title in preview */}
+            <div className="absolute top-0 left-0 right-0 h-8 flex items-center justify-center">
+              <input
+                type="text"
+                value={filename}
+                onChange={(e) => onFilenameChange(e.target.value)}
+                className="bg-transparent text-center text-xs text-white/40 placeholder:text-white/25 border-none outline-none focus:ring-0 focus:outline-none w-48 px-2 py-1 cursor-text"
+                placeholder="Untitled-1"
+              />
+            </div>
           </div>
         )}
       </div>

--- a/components/export-controls.tsx
+++ b/components/export-controls.tsx
@@ -19,6 +19,7 @@ interface ExportControlsProps {
   exportProgress: number;
   onExport: (format: "webm" | "mp4") => void;
   canExport: boolean;
+  filename: string;
 }
 
 export function ExportControls({
@@ -32,6 +33,7 @@ export function ExportControls({
   exportProgress,
   onExport,
   canExport,
+  filename,
 }: ExportControlsProps) {
   const [format, setFormat] = useState<"webm" | "mp4">("webm");
 
@@ -75,7 +77,7 @@ export function ExportControls({
 
         {downloadUrl && (
           <Button variant="outline" size="sm" asChild className="gap-2">
-            <a href={downloadUrl} download={`mellow-lines.${format}`}>
+            <a href={downloadUrl} download={`${filename || "Untitled-1"}.${format}`}>
               <Film className="w-4 h-4" />
               Save Video
             </a>

--- a/components/preview-panel.tsx
+++ b/components/preview-panel.tsx
@@ -25,6 +25,8 @@ interface PreviewPanelProps {
   exportProgress: number;
   onExport: (format: "webm" | "mp4") => void;
   canExport: boolean;
+  filename: string;
+  onFilenameChange: (value: string) => void;
 }
 
 export function PreviewPanel({
@@ -47,6 +49,8 @@ export function PreviewPanel({
   exportProgress,
   onExport,
   canExport,
+  filename,
+  onFilenameChange,
 }: PreviewPanelProps) {
   return (
     <ResizablePanel
@@ -59,6 +63,8 @@ export function PreviewPanel({
         layoutError={layoutError}
         onDismissError={onDismissError}
         isLoading={!stepLayouts}
+        filename={filename}
+        onFilenameChange={onFilenameChange}
       />
 
       <PlayerControls
@@ -82,6 +88,7 @@ export function PreviewPanel({
         exportProgress={exportProgress}
         onExport={onExport}
         canExport={canExport}
+        filename={filename}
       />
     </ResizablePanel>
   );


### PR DESCRIPTION
## Summary
Adds the ability to edit the filename in the preview title bar, similar to how ray.so works.

## Changes
- Added editable filename input in the title bar (centered, between macOS dots)
- Default filename is "Untitled-1"
- Filename appears in exported videos (rendered on canvas)
- Export download uses the custom filename
- Clean implementation: HTML input for preview editing, canvas text for export rendering (no overlap)

## Files Changed
- `app/editor/page.tsx` - Added filename state and passed to components
- `app/lib/magicMove/canvasRenderer.ts` - Added title rendering in title bar
- `components/canvas-preview.tsx` - Added filename input overlay
- `components/preview-panel.tsx` - Added filename props
- `components/export-controls.tsx` - Use filename for download