### PR TITLE
Overhaul layout spacing and macOS-style close dot

### DIFF
--- a/app/lib/magicMove/canvasRenderer.ts
+++ b/app/lib/magicMove/canvasRenderer.ts
@@ -12,7 +12,7 @@ function drawTitleBar(opts: {
   const { ctx, x, y, w, h, theme, title } = opts;
   const dotColor = theme === "dark" ? "rgba(255,255,255,0.15)" : "rgba(0,0,0,0.13)";
   const dotRadius = Math.round(h * 0.18);
-  const dotGap = Math.round(dotRadius * 2.6);
+  const dotGap = Math.round(dotRadius * 3.4);
   const dotsY = y + h / 2;
   const dotsX0 = x + Math.round(h * 0.6);
 

--- a/app/lib/magicMove/codeLayout.ts
+++ b/app/lib/magicMove/codeLayout.ts
@@ -47,7 +47,7 @@ export function makeDefaultLayoutConfig(): CanvasLayoutConfig {
     canvasWidth: 1920,
     canvasHeight: 1080,
     paddingX: 40,
-    paddingY: 40,
+    paddingY: 28,
     lineHeight: 40,
     fontSize: 26,
     fontFamily:
@@ -63,7 +63,7 @@ export function makePreviewLayoutConfig(): CanvasLayoutConfig {
     canvasWidth: 800,
     canvasHeight: 600,
     paddingX: 24,
-    paddingY: 24,
+    paddingY: 16,
     lineHeight: 24,
     fontSize: 16,
     fontFamily:
@@ -87,9 +87,7 @@ export function calculateCanvasHeight(opts: {
 }): number {
   const { lineCount, lineHeight, paddingY, titleBarHeight = 0, minHeight = 0 } = opts;
   const contentHeight = lineCount * lineHeight;
-  // Add extra padding at bottom for visual balance
-  const bottomBuffer = Math.ceil(lineHeight / 2);
-  const totalHeight = contentHeight + paddingY * 2 + titleBarHeight + bottomBuffer;
+  const totalHeight = contentHeight + paddingY * 1.5 + titleBarHeight;
   return Math.ceil(Math.max(minHeight, totalHeight));
 }
 

--- a/components/step-editor-item.tsx
+++ b/components/step-editor-item.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
-import { Trash2 } from "lucide-react";
+import { useState } from "react";
 import { CodeEditor } from "./code-editor";
 import type { ShikiThemeChoice } from "@/app/lib/magicMove/shikiHighlighter";
 import { getThemeBgColor, getThemeVariant } from "@/app/lib/magicMove/shikiHighlighter";
@@ -25,6 +24,7 @@ export function StepEditorItem({
   language,
   theme,
 }: StepEditorItemProps) {
+  const [closeHovered, setCloseHovered] = useState(false);
   const bgColor = getThemeBgColor(theme);
   const variant = getThemeVariant(theme);
   const dotColor = variant === "dark" ? "rgba(255,255,255,0.2)" : "rgba(0,0,0,0.15)";
@@ -37,11 +37,27 @@ export function StepEditorItem({
         style={{ backgroundColor: bgColor }}
       >
         {/* macOS dots */}
-        <div className="flex items-center gap-1">
-          <span
-            className="block w-3 h-3 rounded-full"
-            style={{ backgroundColor: dotColor }}
-          />
+        <div className="flex items-center gap-2">
+          {canRemove ? (
+            <button
+              onClick={onRemove}
+              onMouseEnter={() => setCloseHovered(true)}
+              onMouseLeave={() => setCloseHovered(false)}
+              className="relative flex items-center justify-center w-3 h-3 rounded-full"
+              style={{ backgroundColor: closeHovered ? "#ff5f57" : dotColor }}
+            >
+              {closeHovered && (
+                <svg width="7" height="7" viewBox="0 0 7 7" fill="none" className="absolute">
+                  <path d="M1 1L6 6M6 1L1 6" stroke="rgba(0,0,0,0.6)" strokeWidth="1.2" strokeLinecap="round" />
+                </svg>
+              )}
+            </button>
+          ) : (
+            <span
+              className="block w-3 h-3 rounded-full"
+              style={{ backgroundColor: dotColor }}
+            />
+          )}
           <span
             className="block w-3 h-3 rounded-full"
             style={{ backgroundColor: dotColor }}
@@ -60,19 +76,8 @@ export function StepEditorItem({
           Step {index + 1}
         </span>
 
-        {/* Delete button */}
-        {canRemove ? (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-destructive! hover:bg-transparent!"
-            onClick={onRemove}
-          >
-            <Trash2 className="w-3 h-3" />
-          </Button>
-        ) : (
-          <div className="w-5" />
-        )}
+        {/* Spacer to balance layout */}
+        <div className="w-3" />
       </div>
 
       {/* Code Editor */}


### PR DESCRIPTION
## Summary
- Tighten canvas vertical padding and remove extra bottom buffer for cleaner rendered output
- Increase dot gap in canvas title bar to better match macOS spacing
- Replace trash icon delete button with macOS-style close dot (turns red with × on hover)

## Test plan
- [ ] Verify step editor close dot turns red with × on hover
- [ ] Verify canvas preview and export spacing looks tighter and balanced
- [ ] Verify steps with `canRemove=false` show a plain dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)