### PR TITLE
Make line numbers nearly transparent

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -44,7 +44,7 @@ type CanvasDimensions = {
 export default function Home() {
   const [simpleSteps, setSimpleSteps] = useState<SimpleStep[]>(DEFAULT_STEPS);
   const [selectedLang, setSelectedLang] = useState<string>("typescript");
-  const [simpleShowLineNumbers, setSimpleShowLineNumbers] = useState<boolean>(true);
+  const [simpleShowLineNumbers, setSimpleShowLineNumbers] = useState<boolean>(false);
   const [simpleStartLine, setSimpleStartLine] = useState<number>(1);
 
   const [theme, setTheme] = useState<ShikiThemeChoice>("vitesse-dark");

--- a/app/lib/magicMove/codeLayout.ts
+++ b/app/lib/magicMove/codeLayout.ts
@@ -223,7 +223,7 @@ export function layoutTokenLinesToCanvas(opts: {
   }
 
   const fg = theme === "dark" ? "#e5e7eb" : "#111827";
-  const lineNoColor = theme === "dark" ? "#94a3b8" : "#6b7280";
+  const lineNoColor = theme === "dark" ? "rgba(148,163,184,0.5)" : "rgba(107,114,128,0.5)";
   const dividerColor = theme === "dark" ? "rgba(148,163,184,0.35)" : "rgba(107,114,128,0.35)";
 
   const tokens: LaidToken[] = [];


### PR DESCRIPTION
## Summary
- Change line number color from opaque hex to rgba with 0.5 opacity for a subtler, almost-transparent appearance (both dark and light themes)
- Default line numbers to off

## Test plan
- [ ] Verify line numbers appear faint/translucent in dark theme
- [ ] Verify line numbers appear faint/translucent in light theme
- [ ] Toggle line numbers on/off and confirm behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)