### PR TITLE
Group theme combobox by dark/light with separators

### DIFF
--- a/app/lib/magicMove/shikiHighlighter.ts
+++ b/app/lib/magicMove/shikiHighlighter.ts
@@ -28,6 +28,15 @@ export const AVAILABLE_THEMES: readonly ShikiThemeChoice[] = [
   "kanagawa-lotus",
 ] as const;
 
+export function getGroupedThemes() {
+  const dark = AVAILABLE_THEMES.filter((t) => getThemeVariant(t) === "dark");
+  const light = AVAILABLE_THEMES.filter((t) => getThemeVariant(t) === "light");
+  return [
+    { label: "Dark", items: dark },
+    { label: "Light", items: light },
+  ];
+}
+
 export const AVAILABLE_LANGUAGES = [
   // Web fundamentals
   "javascript",
@@ -78,7 +87,7 @@ export const AVAILABLE_LANGUAGES = [
  * Determine if a Shiki theme is light or dark for rendering purposes.
  */
 export function getThemeVariant(theme: ShikiThemeChoice): "light" | "dark" {
-  const lightThemes: ShikiThemeChoice[] = ["github-light", "vitesse-light"];
+  const lightThemes: ShikiThemeChoice[] = ["github-light", "vitesse-light", "kanagawa-lotus"];
   return lightThemes.includes(theme) ? "light" : "dark";
 }
 

--- a/components/steps-editor-header.tsx
+++ b/components/steps-editor-header.tsx
@@ -10,15 +10,19 @@ import {
 } from "@/components/ui/popover";
 import {
   Combobox,
+  ComboboxCollection,
   ComboboxContent,
   ComboboxEmpty,
+  ComboboxGroup,
   ComboboxInput,
   ComboboxItem,
+  ComboboxLabel,
   ComboboxList,
+  ComboboxSeparator,
 } from "@/components/ui/combobox";
 import {
   AVAILABLE_LANGUAGES,
-  AVAILABLE_THEMES,
+  getGroupedThemes,
   type ShikiThemeChoice,
 } from "@/app/lib/magicMove/shikiHighlighter";
 import { SettingsPopover } from "./settings-popover";
@@ -53,6 +57,8 @@ function formatName(name: string) {
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
 }
+
+const groupedThemes = getGroupedThemes();
 
 export function StepsEditorHeader({
   stepCount,
@@ -108,7 +114,7 @@ export function StepsEditorHeader({
         </Combobox>
 
         <Combobox
-          items={AVAILABLE_THEMES}
+          items={groupedThemes}
           value={theme}
           onValueChange={(v) => v && onThemeChange(v as ShikiThemeChoice)}
           itemToStringLabel={(value) => formatName(value as string)}
@@ -120,10 +126,18 @@ export function StepsEditorHeader({
           <ComboboxContent>
             <ComboboxEmpty>No themes found</ComboboxEmpty>
             <ComboboxList>
-              {(item) => (
-                <ComboboxItem key={item} value={item}>
-                  {formatName(item)}
-                </ComboboxItem>
+              {(group, index) => (
+                <ComboboxGroup key={group.label} items={group.items}>
+                  <ComboboxLabel>{group.label}</ComboboxLabel>
+                  <ComboboxCollection>
+                    {(item) => (
+                      <ComboboxItem key={item} value={item}>
+                        {formatName(item)}
+                      </ComboboxItem>
+                    )}
+                  </ComboboxCollection>
+                  {index < groupedThemes.length - 1 && <ComboboxSeparator />}
+                </ComboboxGroup>
               )}
             </ComboboxList>
           </ComboboxContent>


### PR DESCRIPTION
## Summary
- Theme combobox now groups themes into "Dark" and "Light" sections with a separator
- Groups are derived dynamically from `getThemeVariant()` — no duplicated classification
- Classified `kanagawa-lotus` as a light theme

## Test plan
- [ ] Open the editor and verify the theme combobox shows "Dark" and "Light" groups with a separator
- [ ] Verify all themes appear in the correct group
- [ ] Verify selecting a theme from either group works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)