### PR TITLE
Make MP4 the default export format

### DIFF
--- a/components/export-controls.tsx
+++ b/components/export-controls.tsx
@@ -35,7 +35,7 @@ export function ExportControls({
   canExport,
   filename,
 }: ExportControlsProps) {
-  const [format, setFormat] = useState<"webm" | "mp4">("webm");
+  const [format, setFormat] = useState<"webm" | "mp4">("mp4");
 
   const statusText = exportPhase === "saving" ? "Preparing" : "Recording";
 
@@ -70,8 +70,8 @@ export function ExportControls({
           className="w-fit"
         >
           <TabsList>
-            <TabsTrigger value="webm">WebM</TabsTrigger>
             <TabsTrigger value="mp4">MP4</TabsTrigger>
+            <TabsTrigger value="webm">WebM</TabsTrigger>
           </TabsList>
         </Tabs>
 


### PR DESCRIPTION
## Summary
- Default export format changed from WebM to MP4 for broader compatibility
- MP4 tab now listed first in the format selector

## Test plan
- [ ] Verify export defaults to MP4 when opening export controls
- [ ] Verify MP4 tab appears first in the format selector
- [ ] Verify both MP4 and WebM exports still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)