### PR TITLE
Sync site theme with code theme selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Code quality
+
+After making code changes, always run `npx tsc --noEmit` to check for TypeScript errors and fix any issues before considering the task complete.
+
 ## Git workflow
 
 When asked to commit, always:

--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTheme } from "next-themes";
 import { nanoid } from "nanoid";
 
 import { animateLayouts } from "../lib/magicMove/animate";
@@ -47,7 +48,8 @@ export default function Home() {
   const [simpleShowLineNumbers, setSimpleShowLineNumbers] = useState<boolean>(false);
   const [simpleStartLine, setSimpleStartLine] = useState<number>(1);
 
-  const [theme, setTheme] = useState<ShikiThemeChoice>("vitesse-dark");
+  const [theme, setCodeTheme] = useState<ShikiThemeChoice>("vitesse-dark");
+  const { setTheme: setSiteTheme } = useTheme();
   const [fps, setFps] = useState<number>(60);
   const [transitionMs, setTransitionMs] = useState<number>(700);
   const [startHoldMs, setStartHoldMs] = useState<number>(500);
@@ -676,7 +678,11 @@ export default function Home() {
           selectedLang={selectedLang}
           onLangChange={setSelectedLang}
           theme={theme}
-          onThemeChange={(v) => setTheme(v as ShikiThemeChoice)}
+          onThemeChange={(v) => {
+            const newTheme = v as ShikiThemeChoice;
+            setCodeTheme(newTheme);
+            setSiteTheme(getThemeVariant(newTheme));
+          }}
           showLineNumbers={simpleShowLineNumbers}
           onShowLineNumbersChange={setSimpleShowLineNumbers}
           startLine={simpleStartLine}


### PR DESCRIPTION
## Summary
- Automatically switch the site's light/dark mode when the user selects a code theme (dark code theme → dark site, light code theme → light site)
- Add TypeScript check (`npx tsc --noEmit`) requirement to CLAUDE.md

## Test plan
- [ ] Select a dark code theme (e.g. Dracula) → site switches to dark mode
- [ ] Select a light code theme (e.g. GitHub Light) → site switches to light mode
- [ ] Manual theme toggle in header still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)