### PR TITLE
Increase preview title size and make color theme-aware

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -14,7 +14,7 @@ import {
   makeDefaultLayoutConfig,
   makePreviewLayoutConfig,
 } from "../lib/magicMove/codeLayout";
-import type { LayoutResult } from "../lib/magicMove/codeLayout";
+import type { LayoutResult, RenderTheme } from "../lib/magicMove/codeLayout";
 import {
   getThemeVariant,
   shikiTokenizeToLines,
@@ -729,6 +729,7 @@ export default function Home() {
           canExport={canExport}
           filename={filename}
           onFilenameChange={setFilename}
+          themeVariant={getThemeVariant(theme)}
         />
       </ResizablePanelGroup>
     </div>

--- a/app/lib/magicMove/codeLayout.ts
+++ b/app/lib/magicMove/codeLayout.ts
@@ -70,7 +70,7 @@ export function makePreviewLayoutConfig(): CanvasLayoutConfig {
       'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
     showLineNumbers: false,
     startLine: 1,
-    titleBarHeight: 32,
+    titleBarHeight: 40,
   };
 }
 

--- a/components/canvas-preview.tsx
+++ b/components/canvas-preview.tsx
@@ -3,6 +3,8 @@
 import { useRef } from "react";
 import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import type { RenderTheme } from "@/app/lib/magicMove/codeLayout";
+import { cn } from "@/lib/utils";
 
 interface CanvasPreviewProps {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
@@ -11,6 +13,7 @@ interface CanvasPreviewProps {
   isLoading?: boolean;
   filename: string;
   onFilenameChange: (value: string) => void;
+  themeVariant: RenderTheme;
 }
 
 export function CanvasPreview({
@@ -20,6 +23,7 @@ export function CanvasPreview({
   isLoading,
   filename,
   onFilenameChange,
+  themeVariant,
 }: CanvasPreviewProps) {
   const hasShownRef = useRef(false);
   const shouldAnimate = !isLoading && !hasShownRef.current;
@@ -51,12 +55,17 @@ export function CanvasPreview({
           >
             <canvas ref={canvasRef} className="block" />
             {/* Filename input overlay - displays title in preview */}
-            <div className="absolute top-0 left-0 right-0 h-8 flex items-center justify-center">
+            <div className="absolute top-0 left-0 right-0 h-10 flex items-center justify-center">
               <input
                 type="text"
                 value={filename}
                 onChange={(e) => onFilenameChange(e.target.value)}
-                className="bg-transparent text-center text-xs text-white/40 placeholder:text-white/25 border-none outline-none focus:ring-0 focus:outline-none w-48 px-2 py-1 cursor-text"
+                className={cn(
+                  "bg-transparent text-center text-sm border-none outline-none focus:ring-0 focus:outline-none w-48 px-2 py-1 cursor-text",
+                  themeVariant === "dark"
+                    ? "text-white/60 placeholder:text-white/25"
+                    : "text-black/60 placeholder:text-black/25"
+                )}
                 placeholder="Untitled-1"
               />
             </div>

--- a/components/preview-panel.tsx
+++ b/components/preview-panel.tsx
@@ -4,6 +4,7 @@ import { ResizablePanel } from "@/components/ui/resizable";
 import { CanvasPreview } from "./canvas-preview";
 import { PlayerControls } from "./player-controls";
 import { ExportControls } from "./export-controls";
+import type { RenderTheme } from "@/app/lib/magicMove/codeLayout";
 
 interface PreviewPanelProps {
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
@@ -27,6 +28,7 @@ interface PreviewPanelProps {
   canExport: boolean;
   filename: string;
   onFilenameChange: (value: string) => void;
+  themeVariant: RenderTheme;
 }
 
 export function PreviewPanel({
@@ -51,6 +53,7 @@ export function PreviewPanel({
   canExport,
   filename,
   onFilenameChange,
+  themeVariant,
 }: PreviewPanelProps) {
   return (
     <ResizablePanel
@@ -65,6 +68,7 @@ export function PreviewPanel({
         isLoading={!stepLayouts}
         filename={filename}
         onFilenameChange={onFilenameChange}
+        themeVariant={themeVariant}
       />
 
       <PlayerControls


### PR DESCRIPTION
## Summary
- Bump preview `titleBarHeight` from 32px to 40px for a larger, more readable title
- Derive the filename input overlay color from the selected code theme (`RenderTheme`) instead of the global `dark:` mode
- Use `cn()` for clean conditional Tailwind class composition

## Test plan
- [ ] Switch between light and dark Shiki themes — title input color should match the canvas-rendered title
- [ ] Verify the title overlay aligns with the canvas title bar (no visual misalignment)
- [ ] Export a video and confirm the export title (48px bar) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)