### PR TITLE
Increase preview grid pattern size

### DIFF
--- a/public/grid-pattern-dark.svg
+++ b/public/grid-pattern-dark.svg
@@ -1,7 +1,7 @@
-<svg width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+<svg width="256" height="256" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="white" stroke-opacity="0.05" stroke-width="1"/>
+    <pattern id="grid" width="256" height="256" patternUnits="userSpaceOnUse">
+      <path d="M 256 0 L 0 0 0 256" fill="none" stroke="white" stroke-opacity="0.1" stroke-width="1"/>
     </pattern>
   </defs>
   <rect width="100%" height="100%" fill="url(#grid)" />

--- a/public/grid-pattern.svg
+++ b/public/grid-pattern.svg
@@ -1,7 +1,7 @@
-<svg width="40" height="40" xmlns="http://www.w3.org/2000/svg">
+<svg width="256" height="256" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M 40 0 L 0 0 0 40" fill="none" stroke="black" stroke-opacity="0.05" stroke-width="1"/>
+    <pattern id="grid" width="256" height="256" patternUnits="userSpaceOnUse">
+      <path d="M 256 0 L 0 0 0 256" fill="none" stroke="black" stroke-opacity="0.1" stroke-width="1"/>
     </pattern>
   </defs>
   <rect width="100%" height="100%" fill="url(#grid)" />


### PR DESCRIPTION
## Summary
- Enlarged grid squares from 40px to 256px for a Vercel-style look
- Increased stroke opacity from 0.05 to 0.1 for better visibility

## Test plan
- [ ] Verify grid pattern is visible in both light and dark modes
- [ ] Confirm larger squares look correct in the preview panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)