### PR TITLE
feat: theme-aware default code themes

### DIFF
--- a/app/editor/page.tsx
+++ b/app/editor/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useTheme } from "next-themes";
 import { nanoid } from "nanoid";
 
+import { useDefaultCodeTheme } from "../lib/useDefaultCodeTheme";
 import { animateLayouts } from "../lib/magicMove/animate";
 import { drawCodeFrame } from "../lib/magicMove/canvasRenderer";
 import { animateTyping, computeChangedChars } from "../lib/typing/animateTyping";
@@ -197,8 +197,7 @@ export default function Home() {
   const [simpleShowLineNumbers, setSimpleShowLineNumbers] = useState<boolean>(false);
   const [simpleStartLine, setSimpleStartLine] = useState<number>(1);
 
-  const [theme, setCodeTheme] = useState<ShikiThemeChoice>("vitesse-dark");
-  const { setTheme: setSiteTheme } = useTheme();
+  const { codeTheme: theme, setCodeTheme, setSiteTheme } = useDefaultCodeTheme();
   const [fps, setFps] = useState<number>(60);
   const [transitionMs, setTransitionMs] = useState<number>(700);
   const [startHoldMs, setStartHoldMs] = useState<number>(500);

--- a/app/lib/useDefaultCodeTheme.ts
+++ b/app/lib/useDefaultCodeTheme.ts
@@ -1,0 +1,21 @@
+import { useTheme } from "next-themes";
+import { useState, useEffect, useRef } from "react";
+import type { ShikiThemeChoice } from "./magicMove/shikiHighlighter";
+
+const DARK_DEFAULT: ShikiThemeChoice = "github-dark-default";
+const LIGHT_DEFAULT: ShikiThemeChoice = "github-light-high-contrast";
+
+export function useDefaultCodeTheme() {
+  const { resolvedTheme, setTheme: setSiteTheme } = useTheme();
+  const [codeTheme, setCodeTheme] = useState<ShikiThemeChoice>(DARK_DEFAULT);
+  const initialized = useRef(false);
+
+  // Set code theme based on site theme only on first hydration
+  useEffect(() => {
+    if (initialized.current || !resolvedTheme) return;
+    initialized.current = true;
+    setCodeTheme(resolvedTheme === "light" ? LIGHT_DEFAULT : DARK_DEFAULT);
+  }, [resolvedTheme]);
+
+  return { codeTheme, setCodeTheme, setSiteTheme } as const;
+}


### PR DESCRIPTION
## Summary
- Extract `useDefaultCodeTheme` hook that picks the default code theme based on the user's system light/dark preference
- Dark mode defaults to **Github Dark Default**, light mode defaults to **Github Light High Contrast** (previously hardcoded to Vitesse Dark)
- Manual theme selections are preserved across site theme toggles via a ref guard

## Test plan
- [ ] Open editor in dark mode → code theme should be "Github Dark Default"
- [ ] Open editor in light mode → code theme should be "Github Light High Contrast"
- [ ] Manually switch code theme → selection should persist
- [ ] Toggle site theme → manual selection should be preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)